### PR TITLE
iPhone has nil alertController.popoverPresentationController so canno…

### DIFF
--- a/MetalParticles/ViewController.swift
+++ b/MetalParticles/ViewController.swift
@@ -121,8 +121,9 @@ class ViewController: UIViewController, ParticleLabDelegate
             popoverPresentationController.sourceRect = CGRect(x: xx, y: yy, width: menuButton.frame.width, height: menuButton.frame.height)
             popoverPresentationController.sourceView = view
             
-            presentViewController(alertController, animated: true, completion: nil)
         }
+
+        presentViewController(alertController, animated: true, completion: nil)
     }
  
     func calloutActionHandler(value: UIAlertAction!) -> Void


### PR DESCRIPTION
iPhone has nil alertController.popoverPresentationController so cannott easily control coords of ActionSheet, but should call presentViewController anyway.

closes #22
